### PR TITLE
Increased compatibility of vicor and its output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,111 @@
+# vicor
+
+Easily reduce video size right on your phone! Video files recorded by
+a phone are larger than they need to be. `vicor` offers two modes:
+
+  - "original" which keeps the original image size, but reencodes the
+    video to make the file considerably smaller without noticeable
+    loss in quality;
+  - "small", which rescales the video and reencodes the audio to make
+    the file small enough for a quick share with your friends.
+
+It has a very simple user interface:
+
+  - it shows the list of video files, with TAB completion and with the
+    newest videos available by pressing ↑;
+  - selecting the encoding mode is one key tap;
+  - encoding may take a while, so you can carry the phone in your
+    pocket and `vicor` will vibrate when finished;
+  - it will offer an option to view, send or remove the video, or just
+    let it be.
+
+### Usage example
+
+
+```
+20190707_154855.mp4      VID_20190928_172605.mp4
+VID_20190928_172555.mp4  VID_20190929_162338.mp4
+
+> VID_20190929_162338.mp4
+
+Video size: [o]original [s]mall s
+
+ffmpeg version 4.2 Copyright (c) 2000-2019 the FFmpeg developers
+  built with Android (5220042 based on r346389c) clang version 8.0.7
+
+... lots of ffmpeg output ...
+
+-rw-rw---- 1 root everybody 756K Oct 26 20:34 /data/data/com.termu
+x/files/home/storage/shared/DCIM/vicor//VID_20190929_162338.mp4
+
+[v]iew [s]end [r]emove [q]uit
+```
+
+Selecting `[v]iew` and `[s]end` will keep the menu open.
+
+## Installation
+
+Prerequisites:
+
+  - Termux ([F-Droid](https://f-droid.org/en/packages/com.termux/) or
+    [Play
+    Store](https://play.google.com/store/apps/details?id=com.termux))
+  - ffmpeg installed in Termux
+  - Termux:API to access storage and phone functions
+    ([F-Droid](https://f-droid.org/packages/com.termux.api/) or [Play
+    Store](https://play.google.com/store/apps/details?id=com.termux.api))
+  - Termux:Widget for a handy shortcut
+    ([F-Droid](https://f-droid.org/packages/com.termux.widget/) or
+    [Play
+    Store](https://play.google.com/store/apps/details?id=com.termux.widget))
+
+Please follow the instructions on [Termux
+Wiki](https://wiki.termux.com/wiki/Main_Page) to set up ffmpeg, API
+(permissions, storage) and Widget.
+
+The whole of `vicor` is in the script of the same name. It has a
+couple of settings at the top, which have reasonable defaults, except
+for `videodir` and `outputdir` which you need to set for your
+device. You can change these settings in the `vicor` script directly,
+or you can create a wrapper script that exports the corresponding
+environment variables.
+
+When you have defined video and output directories (and/or other
+settings), place `vicor` or the wrapper script in the `~/.shortcuts`
+directory. This is where Termux-Widget will pick it up. You can then
+add a shortcut to your home screen.
+
+The settings mean the following:
+
+  - `VICOR_VIDEO_DIR`: the directory where `vicor` finds video
+    files. This would tipically be the directory under `DCIM` where
+    your camera app stores recordings.
+  - `VICOR_OUTPUT_DIR`: the directory where `vicor` will save the
+    reencoded videos. They will have the same name as the source
+    files, so *don't set VIDEO and OUTPUT settings to the same
+    directory*.
+  - `VICOR_MAX_SIZE`: when resizing videos, this will be the maximum
+    width (or height, in portrait mode) of the video. For example, a
+    1920x1080 video will be resized to 720x405.
+  - `VICOR_AAC_QUALITY`: when resizing videos, this will be the
+    ffmpeg's quality goal. The default value noticeably reduces file
+    size, but also quality. *When keeping the original video size,
+    audio is not touched*.
+  - `VICOR_FILE_SUFFIX`: defaults to `mp4` and should probably be kept
+    that way, unless you're using `vicor` for something else besides
+    reencoding on a phone.
+
+### An example wrapper script
+
+If you don't want to modify the script directly, you can use a wrapper
+like the one below.
+
+```bash
+#!/data/data/com.termux/files/usr/bin/bash
+
+export VICOR_VIDEO_DIR=$HOME/storage/shared/DCIM/OpenCamera/
+export VICOR_OUTPUT_DIR=$HOME/storage/shared/DCIM/vicor/
+export VICOR_MAX_SIZE=640
+
+exec $HOME/vicor/vicor
+```

--- a/vicor
+++ b/vicor
@@ -1,8 +1,8 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
-videodir='/storage/0123-4567/DCIM/Camera'
-outputdir="${HOME}/vicor/data"
-maxsize=640
+videodir="${VICOR_VIDEO_DIR:-/storage/0123-4567/DCIM/Camera}"
+outputdir="${VICOR_OUTPUT_DIR:-${HOME}/vicor/data}"
+maxsize="${VICOR_MAX_SIZE:-640}"
 
 function is_termux() {
     command -v termux-wake-lock > /dev/null 2>&1

--- a/vicor
+++ b/vicor
@@ -46,7 +46,7 @@ fi
 
 if [[ "$ans" == "s" ]] ; then
     ffmpeg -i "${file}" \
-    -acodec copy \
+    -c:a aac -q:a 0.7 \
     -filter:v scale="w=(trunc(min(a*$maxsize\,$maxsize)/2)*2):h=(trunc(min($maxsize/a\,$maxsize)/2)*2)" \
     -c:v libx264 \
     -profile:v high \

--- a/vicor
+++ b/vicor
@@ -41,6 +41,7 @@ if [[ "$ans" == "s" ]] ; then
     -acodec copy \
     -filter:v scale="trunc(iw*${factor}/2)*2:trunc(ih*${factor}/2)*2" \
     -c:v libx264 \
+    -profile:v high \
     -preset medium \
     -crf 23 \
     "${outfile}"

--- a/vicor
+++ b/vicor
@@ -12,30 +12,30 @@ cd "${videodir}"
 ls *.mp4
 
 for file in *.mp4; do
-  history -s "${file}"
+    history -s "${file}"
 done
 
 read -e -p '> ' file
 if [ -z "${file}" ]; then
-  last="$(ls *.mp4 |tail -n 1)"
-  read -e -p '> ' -i "${last}" file
+    last="$(ls *.mp4 |tail -n 1)"
+    read -e -p '> ' -i "${last}" file
 fi
 
 if [ ! -e "${file}" ]; then
-  echo 'Bailing out' >&2
-  exit 1
+    echo 'Bailing out' >&2
+    exit 1
 fi
 
 outfile="${outputdir}/$(basename "${file}" .mp4).mp4"
 
 while true; do
-read -p "[n]ormal [s]mall " -n 1 ans
-echo
+    read -p "[n]ormal [s]mall " -n 1 ans
+    echo
 
-  case "${ans}" in
-    n) break ;;
-    s) break ;;
-  esac
+    case "${ans}" in
+        n) break ;;
+        s) break ;;
+    esac
 done
 
 if is_termux; then
@@ -83,10 +83,8 @@ while true; do
     case "${ans}" in
         v) $open_command "${outfile}" ;;
         s) $send_command "${outfile}" ;;
-        r)
-        rm "${outfile}"
-        break
-        ;;
+        r) rm "${outfile}"
+           break ;;
         q) break ;;
     esac
 done

--- a/vicor
+++ b/vicor
@@ -38,9 +38,8 @@ termux-wake-lock
 
 if [[ "$ans" == "s" ]] ; then
     ffmpeg -i "${file}" \
+    -acodec copy \
     -filter:v scale="trunc(iw*${factor}/2)*2:trunc(ih*${factor}/2)*2" \
-    -codec:a libmp3lame \
-    -qscale:a 7 \
     -c:v libx264 \
     -preset medium \
     -crf 23 \

--- a/vicor
+++ b/vicor
@@ -3,6 +3,7 @@
 videodir="${VICOR_VIDEO_DIR:-/storage/0123-4567/DCIM/Camera}"
 outputdir="${VICOR_OUTPUT_DIR:-${HOME}/vicor/data}"
 maxsize="${VICOR_MAX_SIZE:-720}"
+aacquality="${VICOR_AAC_QUALITY:-0.7}"
 suffix="${VICOR_FILE_SUFFIX:-mp4}"
 
 function is_termux() {
@@ -46,7 +47,7 @@ fi
 
 if [[ "$ans" == "s" ]] ; then
     ffmpeg -i "${file}" \
-    -c:a aac -q:a 0.7 \
+    -c:a aac -q:a ${aacquality} \
     -filter:v scale="w=(trunc(min(a*$maxsize\,$maxsize)/2)*2):h=(trunc(min($maxsize/a\,$maxsize)/2)*2)" \
     -c:v libx264 \
     -profile:v high \

--- a/vicor
+++ b/vicor
@@ -4,6 +4,10 @@ videodir='/storage/0123-4567/DCIM/Camera'
 outputdir="${HOME}/vicor/data"
 maxsize=640
 
+function is_termux() {
+    command -v termux-wake-lock > /dev/null 2>&1
+}
+
 cd "${videodir}"
 ls *.mp4
 
@@ -33,8 +37,10 @@ echo
     s) break ;;
   esac
 done
-  
-termux-wake-lock
+
+if is_termux; then
+    termux-wake-lock
+fi
 
 if [[ "$ans" == "s" ]] ; then
     ffmpeg -i "${file}" \
@@ -55,23 +61,30 @@ else
     exit 1
 fi
 
-termux-vibrate
-termux-wake-unlock
-echo
+if is_termux; then
+    termux-vibrate
+    termux-wake-unlock
+    open_command='termux-open'
+    send_command='termux-share -a send'
+else
+    open_command='xdg-open'
+    send_command='xdg-email --attach'
+fi
 
+echo
 ls -lh "${outfile}"
 
 while true; do
-  read -p "[v]iew [s]end [r]emove [q]uit " -n 1 ans
-  echo
+    read -p "[v]iew [s]end [r]emove [q]uit " -n 1 ans
+    echo
 
-  case "${ans}" in
-    v) termux-open "${outfile}" ;;
-    s) termux-share -a send "${outfile}" ;;
-    r)
-      rm "${outfile}"
-      break
-      ;;
-    q) break ;;
-  esac
+    case "${ans}" in
+        v) $open_command "${outfile}" ;;
+        s) $send_command "${outfile}" ;;
+        r)
+        rm "${outfile}"
+        break
+        ;;
+        q) break ;;
+    esac
 done

--- a/vicor
+++ b/vicor
@@ -2,7 +2,7 @@
 
 videodir="${VICOR_VIDEO_DIR:-/storage/0123-4567/DCIM/Camera}"
 outputdir="${VICOR_OUTPUT_DIR:-${HOME}/vicor/data}"
-maxsize="${VICOR_MAX_SIZE:-640}"
+maxsize="${VICOR_MAX_SIZE:-720}"
 suffix="${VICOR_FILE_SUFFIX:-mp4}"
 
 function is_termux() {

--- a/vicor
+++ b/vicor
@@ -40,6 +40,7 @@ done
 
 if is_termux; then
     termux-wake-lock
+    trap termux-wake-unlock EXIT
 fi
 
 if [[ "$ans" == "s" ]] ; then
@@ -64,6 +65,7 @@ fi
 if is_termux; then
     termux-vibrate
     termux-wake-unlock
+    trap - EXIT
     open_command='termux-open'
     send_command='termux-share -a send'
 else

--- a/vicor
+++ b/vicor
@@ -2,7 +2,7 @@
 
 videodir='/storage/0123-4567/DCIM/Camera'
 outputdir="${HOME}/vicor/data"
-factor=0.375
+maxsize=640
 
 cd "${videodir}"
 ls *.mp4
@@ -39,7 +39,7 @@ termux-wake-lock
 if [[ "$ans" == "s" ]] ; then
     ffmpeg -i "${file}" \
     -acodec copy \
-    -filter:v scale="trunc(iw*${factor}/2)*2:trunc(ih*${factor}/2)*2" \
+    -filter:v scale="w=(trunc(min(a*$maxsize\,$maxsize)/2)*2):h=(trunc(min($maxsize/a\,$maxsize)/2)*2)" \
     -c:v libx264 \
     -profile:v high \
     -preset medium \

--- a/vicor
+++ b/vicor
@@ -23,17 +23,37 @@ if [ ! -e "${file}" ]; then
 fi
 
 outfile="${outputdir}/$(basename "${file}" .mp4).mp4"
+
+while true; do
+read -p "[n]ormal [s]mall " -n 1 ans
+echo
+
+  case "${ans}" in
+    n) break ;;
+    s) break ;;
+  esac
+done
   
 termux-wake-lock
 
-ffmpeg -i "${file}" \
-  -filter:v scale="trunc(iw*${factor}/2)*2:trunc(ih*${factor}/2)*2" \
-  -codec:a libmp3lame \
-  -qscale:a 7 \
-  -c:v libx264 \
-  -preset medium \
-  -crf 23 \
-  "${outfile}"
+if [[ "$ans" == "s" ]] ; then
+    ffmpeg -i "${file}" \
+    -filter:v scale="trunc(iw*${factor}/2)*2:trunc(ih*${factor}/2)*2" \
+    -codec:a libmp3lame \
+    -qscale:a 7 \
+    -c:v libx264 \
+    -preset medium \
+    -crf 23 \
+    "${outfile}"
+elif [[ "$ans" == "n" ]] ; then
+    ffmpeg -i "${file}" \
+    -acodec copy \
+    -vcodec libx264 \
+    -profile:v high \
+    "${outfile}"
+else
+    exit 1
+fi
 
 termux-vibrate
 termux-wake-unlock

--- a/vicor
+++ b/vicor
@@ -3,21 +3,22 @@
 videodir="${VICOR_VIDEO_DIR:-/storage/0123-4567/DCIM/Camera}"
 outputdir="${VICOR_OUTPUT_DIR:-${HOME}/vicor/data}"
 maxsize="${VICOR_MAX_SIZE:-640}"
+suffix="${VICOR_FILE_SUFFIX:-mp4}"
 
 function is_termux() {
     command -v termux-wake-lock > /dev/null 2>&1
 }
 
 cd "${videodir}"
-ls *.mp4
+ls *.${suffix}
 
-for file in *.mp4; do
+for file in *.${suffix}; do
     history -s "${file}"
 done
 
 read -e -p '> ' file
 if [ -z "${file}" ]; then
-    last="$(ls *.mp4 |tail -n 1)"
+    last="$(ls *.${suffix} |tail -n 1)"
     read -e -p '> ' -i "${last}" file
 fi
 
@@ -26,7 +27,7 @@ if [ ! -e "${file}" ]; then
     exit 1
 fi
 
-outfile="${outputdir}/$(basename "${file}" .mp4).mp4"
+outfile="${outputdir}/$(basename "${file}" .${suffix}).${suffix}"
 
 while true; do
     read -p "[n]ormal [s]mall " -n 1 ans

--- a/vicor
+++ b/vicor
@@ -30,11 +30,11 @@ fi
 outfile="${outputdir}/$(basename "${file}" .${suffix}).${suffix}"
 
 while true; do
-    read -p "[n]ormal [s]mall " -n 1 ans
+    read -p "Video size: [o]original [s]mall " -n 1 ans
     echo
 
     case "${ans}" in
-        n) break ;;
+        o) break ;;
         s) break ;;
     esac
 done
@@ -53,7 +53,7 @@ if [[ "$ans" == "s" ]] ; then
     -preset medium \
     -crf 23 \
     "${outfile}"
-elif [[ "$ans" == "n" ]] ; then
+elif [[ "$ans" == "o" ]] ; then
     ffmpeg -i "${file}" \
     -acodec copy \
     -vcodec libx264 \


### PR DESCRIPTION
There's a number of changes, most of which we've already discussed, and commits are pretty self-explanatory. Still, here's the summary of the idea behind this:
  - Use AAC instead of MP3 because some devices have problems with MP3 inside an MP4 container.
  - Use the "high" profile for x264; while there are devices that will only handle "baseline", they are pretty old by now.
  - Allow vicor to run outside Termux.
  - Allow settings to be specified as environment variables to make it easier to upgrade with `git pull`.